### PR TITLE
Improved replayautouploading reliability 

### DIFF
--- a/AutoReplayUploader/AutoReplayUploader.vcxproj
+++ b/AutoReplayUploader/AutoReplayUploader.vcxproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
+      <DisableSpecificWarnings>4251;4244</DisableSpecificWarnings>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -44,6 +45,7 @@
       <PreprocessorDefinitions>_WINDLL;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;</PreprocessorDefinitions>
     </ClCompile>
     <Link>
+      <GenerateDebugInformation>False</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>BakkesMod.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/AutoReplayUploader/AutoReplayUploaderPlugin.cpp
+++ b/AutoReplayUploader/AutoReplayUploaderPlugin.cpp
@@ -157,7 +157,7 @@ void AutoReplayUploaderPlugin::InitializeVariables()
  
 	// Calculated variables
 	cvarManager->registerCvar(CVAR_UPLOAD_TO_CALCULATED, "0", "Upload to replays to calculated.gg automatically", true, true, 0, true, 1).bindTo(uploadToCalculated);		
-	cvarManager->registerCvar(CVAR_CALCULATED_REPLAY_VISIBILITY, "PUBLIC", "Replay visibility when uploading to calculated.gg", false, false, 0, false, 0, true).bindTo(calculated->visibility);
+	cvarManager->registerCvar(CVAR_CALCULATED_REPLAY_VISIBILITY, "DEFAULT", "Replay visibility when uploading to calculated.gg", false, false, 0, false, 0, true).bindTo(calculated->visibility);
 
 	// Ball Chasing variables	
 	cvarManager->registerCvar(CVAR_UPLOAD_TO_BALLCHASING, "0", "Upload to replays to ballchasing.com automatically", true, true, 0, true, 1).bindTo(uploadToBallchasing);

--- a/AutoReplayUploader/AutoReplayUploaderPlugin.cpp
+++ b/AutoReplayUploader/AutoReplayUploaderPlugin.cpp
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-BAKKESMOD_PLUGIN(AutoReplayUploaderPlugin, "Auto replay uploader plugin", "0.1", 0);
+BAKKESMOD_PLUGIN(AutoReplayUploaderPlugin, "Auto replay uploader plugin", "0.2", 0);
 
 // Constant CVAR variable names
 #define CVAR_REPLAY_EXPORT_PATH "cl_autoreplayupload_filepath"
@@ -32,6 +32,9 @@ BAKKESMOD_PLUGIN(AutoReplayUploaderPlugin, "Auto replay uploader plugin", "0.1",
 #define CVAR_CALCULATED_REPLAY_VISIBILITY "cl_autoreplayupload_calculated_visibility"
 
 string GetPlaylistName(int playlistId);
+Match backupMatchForReplayName;
+bool needToUploadReplay = false;
+string backupPlayerSteamID = "";
 
 void Log(void* object, string message)
 {
@@ -94,9 +97,34 @@ void AutoReplayUploaderPlugin::onLoad()
 
 	InitializeVariables();
 
+
+	// Register for Game ending event	
+	gameWrapper->HookEventWithCaller<ServerWrapper>(
+		"Function GameEvent_Soccar_TA.Active.StartRound",
+		bind(
+			&AutoReplayUploaderPlugin::GetPlayerData,
+			this,
+			placeholders::_1,
+			placeholders::_2,
+			placeholders::_3
+		)
+	);
+
 	// Register for Game ending event	
 	gameWrapper->HookEventWithCaller<ServerWrapper>(
 		"Function TAGame.GameEvent_Soccar_TA.EventMatchEnded",
+		bind(
+			&AutoReplayUploaderPlugin::OnGameComplete,
+			this,
+			placeholders::_1,
+			placeholders::_2,
+			placeholders::_3
+		)
+	);
+
+	// Register for Game ending event	
+	gameWrapper->HookEventWithCaller<ServerWrapper>(
+		"Function TAGame.GameEvent_Soccar_TA.Destroyed",
 		bind(
 			&AutoReplayUploaderPlugin::OnGameComplete,
 			this,
@@ -124,9 +152,12 @@ void AutoReplayUploaderPlugin::onUnload()
 
 void AutoReplayUploaderPlugin::InitializeVariables()
 {
+	// Set the default status of uploading replay to false
+	needToUploadReplay = false;
+ 
 	// Calculated variables
 	cvarManager->registerCvar(CVAR_UPLOAD_TO_CALCULATED, "0", "Upload to replays to calculated.gg automatically", true, true, 0, true, 1).bindTo(uploadToCalculated);		
-	cvarManager->registerCvar(CVAR_CALCULATED_REPLAY_VISIBILITY, "DEFAULT", "Replay visibility when uploading to calculated.gg", false, false, 0, false, 0, false).bindTo(calculated->visibility);
+	cvarManager->registerCvar(CVAR_CALCULATED_REPLAY_VISIBILITY, "PUBLIC", "Replay visibility when uploading to calculated.gg", false, false, 0, false, 0, true).bindTo(calculated->visibility);
 
 	// Ball Chasing variables	
 	cvarManager->registerCvar(CVAR_UPLOAD_TO_BALLCHASING, "0", "Upload to replays to ballchasing.com automatically", true, true, 0, true, 1).bindTo(uploadToBallchasing);
@@ -185,6 +216,19 @@ void AutoReplayUploaderPlugin::OnGameComplete(ServerWrapper caller, void * param
 		return; //Not uploading replays
 	}
 
+    if (needToUploadReplay == false) {
+		// Replay might have already been saved by Function TAGame.GameEvent_Soccar_TA.EventMatchEnded
+		// event if the player stayed in the game long enough. Or we are leaving freeplay, 
+		// custom training, etc instead of online game and will not proceed to upload anything.
+    	return;
+    } else {
+    	// Since the needToUploadReplay was true, we have just finished an online game and this is
+    	// the first time uploading is requested. We will flag that the upload process has 
+    	// now been started and will continue to upload the replay.
+    	needToUploadReplay = false;
+		cvarManager->log("Uploading replay started: " + eventName);
+	}
+
 	// Get ReplayDirector
 	ReplayDirectorWrapper replayDirector = caller.GetReplayDirector();
 	if (replayDirector.IsNull())
@@ -200,17 +244,29 @@ void AutoReplayUploaderPlugin::OnGameComplete(ServerWrapper caller, void * param
 		cvarManager->log("Could not upload replay, replay is NULL!");
 		return;
 	}
-
+	soccarReplay.StopRecord();
+	
 	// If we have a template for the replay name then set the replay name based off that template else use default template
 	string replayName = SetReplayName(caller, soccarReplay);
 
 	// Export the replay to a file for upload
 	string replayPath = ExportReplay(soccarReplay, replayName);
 
+
+	// If we are saving this with event Function TAGame.GameEvent_Soccar_TA.Destroyed
+	// the steamID might not be available. Using prestored steamID
+    string playerSteamID = to_string(gameWrapper->GetSteamID());
+    if (playerSteamID.length() < 1) {
+    	playerSteamID = backupPlayerSteamID;
+		cvarManager->log("Using backup steamId to upload: " + playerSteamID);
+    } else {
+		cvarManager->log("Using steamId to upload: " + playerSteamID);
+    }
+
 	// Upload replay
 	if (*uploadToCalculated)
 	{
-		calculated->UploadReplay(replayPath, replayName, to_string(gameWrapper->GetSteamID()));
+		calculated->UploadReplay(replayPath, replayName, playerSteamID);
 	}
 	if (*uploadToBallchasing)
 	{
@@ -251,6 +307,44 @@ Player ConstructPlayer(PriWrapper wrapper)
 	return p;
 }
 
+void AutoReplayUploaderPlugin::GetPlayerData(ServerWrapper caller, void * params, string eventName)
+{
+    /*****************************************************************************************
+    * This function will save primary player userdata at the start of any online game. There *
+    * are now number of different events that will try to upload the replays after matches.  *
+    * This is needed to make the replay uploads more reliable no matter how fast or slow you *
+    * leave the current game.  In some cases the player data might not be anymore available  * 
+    * when uploading the replay, and that is why we save it in at start of the match.        *
+    *****************************************************************************************/
+	
+	//Function GameEvent_Soccar_TA.Active.StartRound -event will fire in all modes
+	//like freeplay, custom training etc. Set the needToUploadReplay flag replay only 
+	//if we are in an online game.
+	if (gameWrapper->IsInOnlineGame()) {
+	    needToUploadReplay = true;
+	} else {
+		//If we are not in online game, we are in freeplay, custom training etc
+		// We will set the needToUploadReplay flag to false and no need to save the player data.
+	    needToUploadReplay = false;
+	    return;
+	}
+	
+	// We are in online game and now storing some important player data, if needed after the game
+	// When uploading the replay.
+	backupPlayerSteamID = to_string(gameWrapper->GetSteamID());
+
+    CarWrapper mycar = gameWrapper->GetLocalCar();
+    if (!mycar.IsNull()) {
+        PriWrapper mycarpri = mycar.GetPRI();
+        if (!mycarpri.IsNull()) {
+               backupMatchForReplayName.PrimaryPlayer = ConstructPlayer(mycarpri);
+        }
+    }
+
+	cvarManager->log("StartRound: Stored userdata for:" + backupMatchForReplayName.PrimaryPlayer.Name);
+}
+
+
 /**
 * SetReplayName - Called to set the name of the replay in the replay file.
 * Params:
@@ -282,11 +376,24 @@ string AutoReplayUploaderPlugin::SetReplayName(ServerWrapper& server, ReplaySocc
 		match.GameMode = GetPlaylistName(playlist.GetPlaylistId());
 	}
 	// Get local primary player
-	auto localPlayer = server.GetLocalPrimaryPlayer();
-	if (!localPlayer.IsNull())
-	{
-		match.PrimaryPlayer = ConstructPlayer(localPlayer.GetPRI());
-	}
+    CarWrapper mycar = gameWrapper->GetLocalCar();
+    if (!mycar.IsNull()) {
+        PriWrapper mycarpri = mycar.GetPRI();
+        if (!mycarpri.IsNull()) {
+               match.PrimaryPlayer = ConstructPlayer(mycarpri);
+        }
+    }
+
+    // If upload game was initiated by event Function TAGame.GameEvent_Soccar_TA.Destroyed
+    // it is very likely that the primary player data can not be anymore fetched.
+    // That's why we saved this data in Function GameEvent_Soccar_TA.Active.StartRound -event
+    // and will use it, if needed, to get correct player for the game being uploaded.
+    if (match.PrimaryPlayer.Name.length() < 1 && backupMatchForReplayName.PrimaryPlayer.Name.length() > 0){
+	    cvarManager->log("Using prerecorder username for replay: " + backupMatchForReplayName.PrimaryPlayer.Name);
+    	match.PrimaryPlayer.Name = backupMatchForReplayName.PrimaryPlayer.Name;
+    	match.PrimaryPlayer.UniqueId = backupMatchForReplayName.PrimaryPlayer.UniqueId;
+    	match.PrimaryPlayer.Team = backupMatchForReplayName.PrimaryPlayer.Team;
+    }
 
 	// Get all players
 	auto players = server.GetLocalPlayers();
@@ -330,6 +437,7 @@ string AutoReplayUploaderPlugin::ExportReplay(ReplaySoccarWrapper& soccarReplay,
 	}
 
 	// Export Replay
+	
 	soccarReplay.ExportReplay(replayPath);
 	cvarManager->log("Exported replay to: " + replayPath);
 

--- a/AutoReplayUploader/AutoReplayUploaderPlugin.h
+++ b/AutoReplayUploader/AutoReplayUploaderPlugin.h
@@ -46,6 +46,7 @@ public:
 	virtual void onLoad();
 	virtual void onUnload();
 	
+	void GetPlayerData(ServerWrapper caller, void* params, string eventName);
 	void OnGameComplete(ServerWrapper caller, void* params, string eventName);
 
 #ifdef TOAST

--- a/AutoReplayUploader/bakkesmod.props
+++ b/AutoReplayUploader/bakkesmod.props
@@ -5,10 +5,10 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um;F:\SteamLibrary\steamapps\common\rocketleague\Binaries\Win32\bakkesmod\bakkesmodsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um;C:\Program Files (x86)\Steam\steamapps\common\rocketleague\Binaries\Win32\bakkesmod\bakkesmodsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>F:\SteamLibrary\steamapps\common\rocketleague\Binaries\Win32\bakkesmod\bakkesmodsdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files (x86)\Steam\steamapps\common\rocketleague\Binaries\Win32\bakkesmod\bakkesmodsdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/README.md
+++ b/README.md
@@ -5,7 +5,79 @@ BakkesMod plugin that automatically uploads Rocket League replays to other servi
 
 **AutoReplayUploader:** Contains only the plugin code and anything that has to interact with the Bakkes API.
 
-*NOTE: In order to build, the AutoReplayUploader project has to be updated to add the BakkesMod include directory to the compiler properties as well as adding the folder that contains the bakkesmod.dll to the additional library directory in the linker.*
+* NOTE: The project had lots of warnings when compiling in VS2019 build tools. 
+  The are silenced for now by adding to ConsoleUploader.vcxproj:
+  
+  <ClCompile>
+  <DisableSpecificWarnings>4251;4244</DisableSpecificWarnings>
+  ...
+  and:
+  <Link>
+  <GenerateDebugInformation>False</GenerateDebugInformation>
+  ...
+
+  More info about warnings:
+    Compiler Warning (level 1) C4251
+      -'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
+    Compiler Warning (levels 3 and 4) C4244
+      -'conversion' conversion from 'type1' to 'type2', possible loss of data
+    Linker Tools Warning LNK4099
+      -PDB 'filename' was not found with 'object/library' or at 'path'; linking object as if no debug info
+
+
+**NOTE2: In order to build, the AutoReplayUploader project has to be updated to add the BakkesMod include directory to the compiler properties as well as adding the folder that contains the bakkesmod.dll to the additional library directory in the linker.*
+
+Bakkesmod folders can be set in:
+AutoReplayUploader/AutoReplayUploader/bakkesmod.props
+
+Can be compiled with Visual Studio Build Tools 2019
+* Use the Developer PowerShell for VS 2019
+* To build the project: 
+----------------------
+* You must go to AutoReplayUploader folder with the: AutoReplayUploader.sln
+* Build the project with command:
+  - msbuild AutoReplayUploader.sln /p:PlatformToolset=v141 -p:Configuration=Release
+* if you have trouble with paths you can try running:
+  - &'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars32.bat'
+----------------------
+
+For the Visual Studio Build Tools 2019 I had these packages installed (in Win10):
+Installation details.
+MSBuild Tools 
+- Provides the tools required to build MSBuild-based applications. 
+
+C++ build tools:
+Included:
+- C++ Build Tools core features
+- C++ 2019 Redistributable Update
+- Optional:
+- MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.23)
+- Windows 10 SDK (10.0.18362.0)
+- C++ CMake tools for Windows
+- Windows 10 SDK (10.0.17763.0)
+- Windows 10 SDK (10.0.17134.0)
+- MSVC v141 - VS 2017 C++ x64/x86 build tools (v14.16)
+- MSVC v140 - VS 2015 C++ build tools (v14.00)
+
+Individual components
+- C# and Visual Basic Roslyn compilers
+- MSBuild
+- C++ 2019 Redistributable Update
+- C++ Clang Compiler for Windows (8.0.1)
+- Windows 10 SDK (10.0.17763.0)
+- Windows 10 SDK (10.0.17134.0)
+- Text Template Transformation
+- C++ core features
+- MSVC v141 - VS 2017 C++ x64/x86 build tools (v14.16)
+- Windows Universal CRT SDK
+- MSVC v140 - VS 2015 C++ build tools (v14.00)
+- NuGet targets and build tasks
+- .NET Framework 4.6 targeting pack
+- ClickOnce Build Tools
+- Visual Studio SDK Build Tools Core
+- NuGet package manager
+- MSVC v141 - VS 2017 C++ x64/x86 Spectre-mitigated libs (v14.16)
+
 
 **Uploader:** Contains all code to upload replays to an endpoint and does not have any dependencies on the Bakkes API.
 

--- a/Uploader/Calculated.h
+++ b/Uploader/Calculated.h
@@ -13,7 +13,7 @@ public:
 	Calculated(string userAgent, void(*log)(void* object, string message), void(*NotifyUploadResult)(void* object, bool result), void* client);
 	~Calculated();
 
-	shared_ptr<string> visibility = make_shared<string>("PUBLIC");
+	shared_ptr<string> visibility = make_shared<string>("DEFAULT");
 
 	void(*Log)(void* object, string message);
 	void(*NotifyUploadResult)(void* object, bool result);

--- a/Uploader/Calculated.h
+++ b/Uploader/Calculated.h
@@ -13,7 +13,7 @@ public:
 	Calculated(string userAgent, void(*log)(void* object, string message), void(*NotifyUploadResult)(void* object, bool result), void* client);
 	~Calculated();
 
-	shared_ptr<string> visibility = make_shared<string>("DEFAULT");
+	shared_ptr<string> visibility = make_shared<string>("PUBLIC");
 
 	void(*Log)(void* object, string message);
 	void(*NotifyUploadResult)(void* object, bool result);

--- a/Uploader/Replay.h
+++ b/Uploader/Replay.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Utils.h"
 
 #include <string>
 #include "Match.h"

--- a/autoreplayuploader.set
+++ b/autoreplayuploader.set
@@ -1,6 +1,6 @@
 Auto replay uploader
 1|Enable automatic replay uploading to calculated.gg|cl_autoreplayupload_calculated
-6|Replay visibility|cl_autoreplayupload_calculated_visibility|PUBLIC@PUBLIC&PRIVATE@PRIVATE&DEFAULT@DEFAULT
+6|Replay visibility|cl_autoreplayupload_calculated_visibility|DEFAULT@DEFAULT&PUBLIC@PUBLIC&PRIVATE@PRIVATE
 8|
 1|Enable automatic replay uploading to ballchasing.com|cl_autoreplayupload_ballchasing
 6|Replay visibility|cl_autoreplayupload_ballchasing_visibility|public@public&private@private&unlisted@unlisted

--- a/autoreplayuploader.set
+++ b/autoreplayuploader.set
@@ -1,9 +1,9 @@
 Auto replay uploader
 1|Enable automatic replay uploading to calculated.gg|cl_autoreplayupload_calculated
-6|Replay visibility|cl_autoreplayupload_calculated_visibility|DEFAULT@DEFAULT&PUBLIC@PUBLIC&PRIVATE@PRIVATE
+6|Calculated replay visibility|cl_autoreplayupload_calculated_visibility|DEFAULT@DEFAULT&PUBLIC@PUBLIC&PRIVATE@PRIVATE
 8|
 1|Enable automatic replay uploading to ballchasing.com|cl_autoreplayupload_ballchasing
-6|Replay visibility|cl_autoreplayupload_ballchasing_visibility|public@public&private@private&unlisted@unlisted
+6|Ballchasing replay visibility|cl_autoreplayupload_ballchasing_visibility|public@public&private@private&unlisted@unlisted
 12|Ballchasing auth key|cl_autoreplayupload_ballchasing_authkey
 9|Ballchasing requires an authentication key to autoupload replays. Get one at https://ballchasing.com/upload
 9|Auth key status: $cl_autoreplayupload_ballchasing_testkeyresult$

--- a/autoreplayuploader.set
+++ b/autoreplayuploader.set
@@ -1,5 +1,6 @@
 Auto replay uploader
 1|Enable automatic replay uploading to calculated.gg|cl_autoreplayupload_calculated
+6|Replay visibility|cl_autoreplayupload_calculated_visibility|PUBLIC@PUBLIC&PRIVATE@PRIVATE&DEFAULT@DEFAULT
 8|
 1|Enable automatic replay uploading to ballchasing.com|cl_autoreplayupload_ballchasing
 6|Replay visibility|cl_autoreplayupload_ballchasing_visibility|public@public&private@private&unlisted@unlisted


### PR DESCRIPTION
Improved replayautouploading reliability 

- Set the project to build with VS 2019 build tools, check readme.
- lots of replays went unuploaded due to player leaving the game immediately etc, now we pretty much upload replays for 100% of the games (not including games in which you drop out of game totally and reconnect).  Couple of replays didn't appear in calculated, but they are known parsing errors at calculated's end, they wont upload manually eather, but work great in RL replay viewer.
- added replay upload hook to "Function TAGame.GameEvent_Soccar_TA.Destroyed",
this happens after every game no matter how fast you leave the game.
- Added GetPlayerData to "Function GameEvent_Soccar_TA.Active.StartRound" -hook, this fires always at the start of match.  If we are uploading through destroyed event, the user data might not be available otherwise.
- silenced a bunch of compile/linker warnings, see readme. 
- Added UI Selection to upload as default, private or public for calculated.gg too

Todo for when adding to bakkesmod installer:
- Make sure to add the new autoreplayuploader.set to package as well
- Just in case add new config to config.cfg:
  cl_autoreplayupload_calculated_visibility "DEFAULT" //Replay visibility when uploading to calculated.gg
