### PR TITLE
Prevent the upload of online freeplay replays by default.

### DIFF
--- a/AutoReplayUploader/AutoReplayUploaderPlugin.cpp
+++ b/AutoReplayUploader/AutoReplayUploaderPlugin.cpp
@@ -451,20 +451,18 @@ void AutoReplayUploaderPlugin::GetPlayerData(ServerWrapper caller, void* params,
     * when uploading the replay, and that is why we save it in at start of the match.        *
     *****************************************************************************************/
 	
-	//Function GameEvent_Soccar_TA.Active.StartRound -event will fire in all modes
-	//like freeplay, custom training etc. Set the needToUploadReplay flag replay only 
-	//if we are in an online game.
+	// Function GameEvent_Soccar_TA.Active.StartRound -event will fire in all modes
+	// like freeplay, custom training etc. Set the needToUploadReplay flag replay only 
+	// if we are in an online game. Online freeplay is also an online game mode, but we will
+	// only upload those replays if CVAR_UPLOAD_ONLINE_FREEPLAY (bound to uploadOnlineFreeplay)
+	// has been set to true.
+
 	int playlistID = caller.GetPlaylist().GetPlaylistId();
-	bool uploadReplay = gameWrapper->IsInOnlineGame() && ((playlistID == 73) ? *uploadOnlineFreeplay : false);
-	if (uploadReplay) {
-		needToUploadReplay = true;
-	} else {
-		//If we are not in online game, we are in freeplay, custom training etc
-		// We will set the needToUploadReplay flag to false and no need to save the player data.
-	    needToUploadReplay = false;
-	    return;
+	needToUploadReplay = gameWrapper->IsInOnlineGame() && (playlistID != ONLINE_FREEPLAY_PLAYLIST_ID ? true : *uploadOnlineFreeplay);
+	if (!needToUploadReplay) {
+		return;
 	}
-	
+
 	// We are in online game and now storing some important player data, if needed after the game
 	// When uploading the replay.
 	backupPlayerSteamID = std::to_string(gameWrapper->GetSteamID());

--- a/AutoReplayUploader/AutoReplayUploaderPlugin.h
+++ b/AutoReplayUploader/AutoReplayUploaderPlugin.h
@@ -10,6 +10,7 @@
 
 #define DEAULT_EXPORT_PATH "./bakkesmod/data/"
 #define DEFAULT_REPLAY_NAME_TEMPLATE "{YEAR}-{MONTH}-{DAY}.{HOUR}.{MIN} {PLAYER} {MODE} {WINLOSS}"
+#define ONLINE_FREEPLAY_PLAYLIST_ID 73
 
 // TODO: uncomment or remove #ifdef's when new Bakkes mod API becomes available that has Toast notifications
 //#define TOAST

--- a/AutoReplayUploader/AutoReplayUploaderPlugin.h
+++ b/AutoReplayUploader/AutoReplayUploaderPlugin.h
@@ -25,6 +25,7 @@ private:
 	std::shared_ptr<bool> uploadToCalculated = std::make_shared<bool>(false);
 	std::shared_ptr<bool> uploadToBallchasing = std::make_shared<bool>(false);
 	std::shared_ptr<bool> uploadToBallchasingMMR = std::make_shared<bool>(false);
+	std::shared_ptr<bool> uploadOnlineFreeplay = std::make_shared<bool>(false);
 
 	// Replay name template variables
 	std::shared_ptr<int> templateSequence = std::make_shared<int>(0);

--- a/AutoReplayUploader/bakkesmod.props
+++ b/AutoReplayUploader/bakkesmod.props
@@ -10,7 +10,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(BakkesModPath)\bakkesmodsdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bakkesmod.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pluginsdk.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>python "$(BakkesModPath)\bakkesmodsdk\bakkes_patchplugin.py" "$(TargetPath)"</Command>

--- a/autoreplayuploader.set
+++ b/autoreplayuploader.set
@@ -15,3 +15,6 @@ Auto replay uploader
 1|Save all replay files to export filepath below|cl_autoreplayupload_save
 12|Path to export replays to|cl_autoreplayupload_filepath
 9|Note: For this to work, you do NOT have to have "save all replays" enabled!
+8|
+1|Upload Online Freeplay replays|cl_autoreplayupload_online_freeplay
+9|Note: You probably do not want to upload Online Freeplay replays.


### PR DESCRIPTION
Also moved from away from some deprecated member functions that were preventing the build.

I had to update bakkesmod.props to point to `pluginsdk.lib` as well.

I don't have a lot of experience with C++ or Windows dev, so I'm sorry for any bad choices I might be making here. It appears to be a pretty simple fix though and It Works For Me™.